### PR TITLE
Disabled the font-weight property to make the navbar links show properly

### DIFF
--- a/src/components/UI/navbar.scss
+++ b/src/components/UI/navbar.scss
@@ -4,7 +4,7 @@
     background-color: #444;
     font-family: Lato, sans-serif;
     color: #fff;
-    font-weight: 400;
+    // font-weight: 400;
     z-index: 10;
     height: 60px;
     padding-top: 0;
@@ -17,7 +17,7 @@
     .navbarlink {
         color: #fff;
         font-size: 15px;
-        font-weight: 200;
+        // font-weight: 200;
         text-transform: uppercase;
         .nav-link {
             -webkit-transition: background-color 500ms ease;
@@ -31,7 +31,7 @@
     .n-dropdown-link {
         font-family: Lato, sans-serif;
         font-size: 15px;
-        font-weight: 100;
+       // font-weight: 100;
         text-transform: uppercase;
         text-align: left;
         margin-left: auto;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The css `font-weight` property is causing the navbar links to show incorrectly and almost invisible. So disabling it for now.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/Fairshots/Fairshots.org/issues/56

## Motivation and Context
Refer to this link for more context (https://github.com/Fairshots/Fairshots.org/issues/56)

## How Has This Been Tested?
Yes. the link above shows the screenshots after making the necessary changes.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
